### PR TITLE
Remove Duplicate Profile Username

### DIFF
--- a/src/common/components/profile-card/index.tsx
+++ b/src/common/components/profile-card/index.tsx
@@ -171,7 +171,6 @@ export const ProfileCard = (props: Props) => {
 
             {(account.profile?.name || account.profile?.about) && (
                 <div className="basic-info">
-                    {account.profile?.name && <div className="full-name">{account.profile.name}</div>}
                     {account.profile?.about && <div className="about">{account.profile.about}</div>}
                 </div>
             )}

--- a/src/common/pages/sign-up.tsx
+++ b/src/common/pages/sign-up.tsx
@@ -240,7 +240,7 @@ const SignUpPage = (props: Props | any) => {
                 {step == 1 && (
                   <div className="sign-up">
                     <div className="the-form">
-                      <div className="form-title">Create a Hive acoount</div>
+                      <div className="form-title">Create a Hive account</div>
                       <div className="form-sub-title">
                         {_t("sign-up.description")}
                       </div>


### PR DESCRIPTION
Fixes #28.

As per codes, it seems the original codes aims  to display the user's fullname. 

![image](https://github.com/spknetwork/ecency-boilerplate/assets/29425738/6143bf18-d912-4253-8859-84da8d075dc2)
